### PR TITLE
Fix links to jsontypedef.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,5 +229,5 @@ validateUntrusted(jtd.Schema{
 [badge]: https://godoc.org/github.com/jsontypedef/json-typedef-go?status.svg
 [godoc]: https://godoc.org/github.com/jsontypedef/json-typedef-go
 [jtd]: https://jsontypedef.com
-[jtd-go-codegen]: https://jsontypedef.com/docs/go/code-generation
-[jtd-go-validation]: https://jsontypedef.com/docs/go/validation
+[jtd-go-codegen]: https://jsontypedef.com/docs/golang/code-generation
+[jtd-go-validation]: https://jsontypedef.com/docs/golang/validation


### PR DESCRIPTION
Some links in the README are broken, because they use "go" instead of "golang" in the URL.